### PR TITLE
fix: Correct Pygame loading in Pyodide via micropip

### DIFF
--- a/IPL-3.0/templates/animation_player.html
+++ b/IPL-3.0/templates/animation_player.html
@@ -34,9 +34,15 @@
             statusElement.textContent = "Pyodide loaded. Loading micropip and pygame-ce...";
 
             // Load micropip for installing packages from PyPI
-            await pyodide.loadPackage(["micropip"]);
-            // Install pygame-ce (Community Edition) using micropip
-            await pyodide.micropip.install("pygame-ce");
+            await pyodide.loadPackage("micropip"); // Load micropip package itself
+
+            // Now, run Python code via Pyodide to use the loaded micropip
+            await pyodide.runPythonAsync(`
+                import micropip
+                print("Attempting to install pygame-ce with micropip from Python...")
+                await micropip.install('pygame-ce')
+                print("pygame-ce installation attempt complete.")
+            `);
             statusElement.textContent = "Pygame-ce loaded. Fetching animation script...";
 
             // Fetch the Python animation script


### PR DESCRIPTION
Addresses the 'TypeError: Cannot read properties of undefined (reading 'install')' error when you try to install pygame-ce.

The `animation_player.html` script was updated to load the `micropip` package and then use `pyodide.runPythonAsync()` to execute Python code that imports `micropip` and calls `micropip.install('pygame-ce')`. This ensures that `micropip.install` is invoked from within the Pyodide's Python environment, which is a more robust method for package installation.

This change is critical for enabling the Pygame-based animation (`cricket_animation.py`) to run in the browser.